### PR TITLE
[fix] Reloading of fail2ban

### DIFF
--- a/ynh_add_fail2ban_config/ynh_add_fail2ban_config
+++ b/ynh_add_fail2ban_config/ynh_add_fail2ban_config
@@ -42,7 +42,7 @@ EOF
   ynh_store_file_checksum "$finalfail2banjailconf"
   ynh_store_file_checksum "$finalfail2banfilterconf"
   
-  fail2ban-client reload
+  systemctl reload fail2ban
   local fail2ban_error="$(journalctl -u fail2ban | tail -n50 | grep "WARNING.*$app.*")"
   if [ -n "$fail2ban_error" ]
   then
@@ -57,5 +57,5 @@ EOF
 ynh_remove_fail2ban_config () {
   ynh_secure_remove "/etc/fail2ban/jail.d/$app.conf"
   ynh_secure_remove "/etc/fail2ban/filter.d/$app.conf"
-  fail2ban-client reload
+  systemctl reload fail2ban
 }

--- a/ynh_add_fail2ban_config/ynh_add_fail2ban_config
+++ b/ynh_add_fail2ban_config/ynh_add_fail2ban_config
@@ -42,7 +42,7 @@ EOF
   ynh_store_file_checksum "$finalfail2banjailconf"
   ynh_store_file_checksum "$finalfail2banfilterconf"
   
-  systemctl restart fail2ban
+  fail2ban-client reload
   local fail2ban_error="$(journalctl -u fail2ban | tail -n50 | grep "WARNING.*$app.*")"
   if [ -n "$fail2ban_error" ]
   then
@@ -57,5 +57,5 @@ EOF
 ynh_remove_fail2ban_config () {
   ynh_secure_remove "/etc/fail2ban/jail.d/$app.conf"
   ynh_secure_remove "/etc/fail2ban/filter.d/$app.conf"
-  sudo systemctl restart fail2ban
+  sudo fail2ban-client reload
 }

--- a/ynh_add_fail2ban_config/ynh_add_fail2ban_config
+++ b/ynh_add_fail2ban_config/ynh_add_fail2ban_config
@@ -57,5 +57,5 @@ EOF
 ynh_remove_fail2ban_config () {
   ynh_secure_remove "/etc/fail2ban/jail.d/$app.conf"
   ynh_secure_remove "/etc/fail2ban/filter.d/$app.conf"
-  sudo fail2ban-client reload
+  fail2ban-client reload
 }


### PR DESCRIPTION
Hello

To update the fail2ban jails the systemctl restart fail2ban command is not the right one because you have to restart fail2ban-client which manages the jails.