### PR TITLE
Use ynh_handle_getopts_args

### DIFF
--- a/is_url_handled/is_url_handled
+++ b/is_url_handled/is_url_handled
@@ -1,10 +1,18 @@
 #!/bin/bash
 
+# Need also the helper https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_handle_getopts_args/ynh_handle_getopts_args
+
 # Check if an URL is already handled
 # usage: is_url_handled URL
 is_url_handled() {
+  # Declare an array to define the options of this helper.
+  declare -Ar args_array=( [u]=url= )
+  local url
+  # Manage arguments with getopts
+  ynh_handle_getopts_args "$@"
+
   local output=($(curl -k -s -o /dev/null \
-      -w 'x%{redirect_url} %{http_code}' "$1"))
+      -w 'x%{redirect_url} %{http_code}' "$url"))
   # It's handled if it does not redirect to the SSO nor return 404
   [[ ! ${output[0]} =~ \/yunohost\/sso\/ && ${output[1]} != 404 ]]
 }

--- a/postgres/postgres
+++ b/postgres/postgres
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Need also the helper https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_handle_getopts_args/ynh_handle_getopts_args
+
 #=================================================
 #
 # POSTGRES HELPERS
@@ -51,34 +53,50 @@ ynh_psql_test_if_first_run() {
 # example: ynh_psql_connect_as 'user' 'pass' < /path/to/file.sql
 #
 # usage: ynh_psql_connect_as user pwd [db]
-# | arg: user - the user name to connect as
-# | arg: pwd - the user password
-# | arg: db - the database to connect to
+# | arg: -u, --user= - the user name to connect as
+# | arg: -p, --pwd= - the user password
+# | arg: -d, --db= - the database to connect to
 ynh_psql_connect_as() {
-	user="$1"
-	pwd="$2"
-	db="$3"
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [u]=user= [p]=pwd= [d]=db=)
+	local user
+	local pwd
+	local db
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+
 	sudo --login --user=postgres PGUSER="$user" PGPASSWORD="$pwd" psql "$db"
 }
 
 # # Execute a command as root user
 #
 # usage: ynh_psql_execute_as_root sql [db]
-# | arg: sql - the SQL command to execute
-# | arg: db - the database to connect to
+# | arg: -s, --sql= - the SQL command to execute
+# | arg: -d, --db= - the database to connect to
 ynh_psql_execute_as_root () {
-	sql="$1"
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [s]=sql= [d]=db= )
+	local sql
+	local db
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+
 	sudo --login --user=postgres psql <<< "$sql"
 }
 
 # Execute a command from a file as root user
 #
 # usage: ynh_psql_execute_file_as_root file [db]
-# | arg: file - the file containing SQL commands
-# | arg: db - the database to connect to
+# | arg: -f, --file= - the file containing SQL commands
+# | arg: -d, --db= - the database to connect to
 ynh_psql_execute_file_as_root() {
-	file="$1"
-	db="$2"
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [f]=file= [d]=db= )
+	local file
+	local db
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+
 	sudo --login --user=postgres psql "$db" < "$file"
 }
 
@@ -92,11 +110,16 @@ ynh_psql_execute_file_as_root() {
 # | arg: name - Name of the database
 # | arg: pwd - Password of the database. If not given, a password will be generated
 ynh_psql_setup_db () {
-	db_user="$1"
-	db_name="$2"
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [u]=db_user= [n]=db_name= [p]=db_pwd= )
+	local db_user
+	local db_name
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
 	new_db_pwd=$(ynh_string_random)	# Generate a random password
 	# If $3 is not given, use new_db_pwd instead for db_pwd.
-	db_pwd="${3:-$new_db_pwd}"
+	db_pwd="${db_pwd:-$new_db_pwd}"
+
 	ynh_psql_create_db "$db_name" "$db_user" "$db_pwd"	# Create the database
 	ynh_app_setting_set "$app" psqlpwd "$db_pwd"	# Store the password in the app's config
 }

--- a/postgres/postgres
+++ b/postgres/postgres
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# Need also the helper https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_handle_getopts_args/ynh_handle_getopts_args
-
 #=================================================
 #
 # POSTGRES HELPERS
@@ -53,50 +51,34 @@ ynh_psql_test_if_first_run() {
 # example: ynh_psql_connect_as 'user' 'pass' < /path/to/file.sql
 #
 # usage: ynh_psql_connect_as user pwd [db]
-# | arg: -u, --user= - the user name to connect as
-# | arg: -p, --pwd= - the user password
-# | arg: -d, --db= - the database to connect to
+# | arg: user - the user name to connect as
+# | arg: pwd - the user password
+# | arg: db - the database to connect to
 ynh_psql_connect_as() {
-	# Declare an array to define the options of this helper.
-	declare -Ar args_array=( [u]=user= [p]=pwd= [d]=db=)
-	local user
-	local pwd
-	local db
-	# Manage arguments with getopts
-	ynh_handle_getopts_args "$@"
-
+	user="$1"
+	pwd="$2"
+	db="$3"
 	sudo --login --user=postgres PGUSER="$user" PGPASSWORD="$pwd" psql "$db"
 }
 
 # # Execute a command as root user
 #
 # usage: ynh_psql_execute_as_root sql [db]
-# | arg: -s, --sql= - the SQL command to execute
-# | arg: -d, --db= - the database to connect to
+# | arg: sql - the SQL command to execute
+# | arg: db - the database to connect to
 ynh_psql_execute_as_root () {
-	# Declare an array to define the options of this helper.
-	declare -Ar args_array=( [s]=sql= [d]=db= )
-	local sql
-	local db
-	# Manage arguments with getopts
-	ynh_handle_getopts_args "$@"
-
+	sql="$1"
 	sudo --login --user=postgres psql <<< "$sql"
 }
 
 # Execute a command from a file as root user
 #
 # usage: ynh_psql_execute_file_as_root file [db]
-# | arg: -f, --file= - the file containing SQL commands
-# | arg: -d, --db= - the database to connect to
+# | arg: file - the file containing SQL commands
+# | arg: db - the database to connect to
 ynh_psql_execute_file_as_root() {
-	# Declare an array to define the options of this helper.
-	declare -Ar args_array=( [f]=file= [d]=db= )
-	local file
-	local db
-	# Manage arguments with getopts
-	ynh_handle_getopts_args "$@"
-
+	file="$1"
+	db="$2"
 	sudo --login --user=postgres psql "$db" < "$file"
 }
 
@@ -110,16 +92,11 @@ ynh_psql_execute_file_as_root() {
 # | arg: name - Name of the database
 # | arg: pwd - Password of the database. If not given, a password will be generated
 ynh_psql_setup_db () {
-	# Declare an array to define the options of this helper.
-	declare -Ar args_array=( [u]=db_user= [n]=db_name= [p]=db_pwd= )
-	local db_user
-	local db_name
-	# Manage arguments with getopts
-	ynh_handle_getopts_args "$@"
+	db_user="$1"
+	db_name="$2"
 	new_db_pwd=$(ynh_string_random)	# Generate a random password
 	# If $3 is not given, use new_db_pwd instead for db_pwd.
-	db_pwd="${db_pwd:-$new_db_pwd}"
-
+	db_pwd="${3:-$new_db_pwd}"
 	ynh_psql_create_db "$db_name" "$db_user" "$db_pwd"	# Create the database
 	ynh_app_setting_set "$app" psqlpwd "$db_pwd"	# Store the password in the app's config
 }

--- a/send_readme_to_admin/send_readme_to_admin
+++ b/send_readme_to_admin/send_readme_to_admin
@@ -1,16 +1,24 @@
 #!/bin/bash
 
+# Need also the helper https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_handle_getopts_args/ynh_handle_getopts_args
+
 # Send an email to inform the administrator
 #
 # usage: ynh_send_readme_to_admin app_message [recipients]
-# | arg: app_message - The message to send to the administrator.
-# | arg: recipients - The recipients of this email. Use spaces to separate multiples recipients. - default: root
+# | arg: -m --app_message= - The message to send to the administrator.
+# | arg: -r, --recipients= - The recipients of this email. Use spaces to separate multiples recipients. - default: root
 #	example: "root admin@domain"
 #	If you give the name of a YunoHost user, ynh_send_readme_to_admin will find its email adress for you
 #	example: "root admin@domain user1 user2"
 ynh_send_readme_to_admin() {
-	local app_message="${1:-...No specific information...}"
-	local recipients="${2:-root}"
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [m]=app_message= [r]=recipients= )
+	local app_message
+	local recipients
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+	local app_message="${app_message:-...No specific information...}"
+	local recipients="${recipients:-root}"
 
 	# Retrieve the email of users
 	find_mails () {

--- a/ynh_add_fail2ban_config/ynh_add_fail2ban_config
+++ b/ynh_add_fail2ban_config/ynh_add_fail2ban_config
@@ -1,27 +1,34 @@
 #!/bin/bash
 
+# Need also the helper https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_handle_getopts_args/ynh_handle_getopts_args
+
 # Create a dedicated fail2ban config (jail and filter conf files)
 #
 # usage: ynh_add_fail2ban_config log_file filter [max_retry [ports]]
-# | arg: log_file - Log file to be checked by fail2ban
-# | arg: failregex - Failregex to be looked for by fail2ban
-# | arg: max_retry - Maximum number of retries allowed before banning IP address - default: 3
-# | arg: ports - Ports blocked for a banned IP address - default: http,https
+# | arg: -l, --logpath= - Log file to be checked by fail2ban
+# | arg: -r, --failregex= - Failregex to be looked for by fail2ban
+# | arg: -m, --max_retry= - Maximum number of retries allowed before banning IP address - default: 3
+# | arg: -p, --ports= - Ports blocked for a banned IP address - default: http,https
 ynh_add_fail2ban_config () {
-   # Process parameters
-   logpath=$1
-   failregex=$2
-   max_retry=${3:-3}
-   ports=${4:-http,https}
-   
+  # Declare an array to define the options of this helper.
+  declare -Ar args_array=( [l]=logpath= [r]=failregex= [m]=max_retry= [p]=ports= )
+  local logpath
+  local failregex
+  local max_retry
+  local ports
+  # Manage arguments with getopts
+  ynh_handle_getopts_args "$@"
+  max_retry=${max_retry:-3}
+  ports=${ports:-http,https}
+
   test -n "$logpath" || ynh_die "ynh_add_fail2ban_config expects a logfile path as first argument and received nothing."
   test -n "$failregex" || ynh_die "ynh_add_fail2ban_config expects a failure regex as second argument and received nothing."
-  
+
   finalfail2banjailconf="/etc/fail2ban/jail.d/$app.conf"
   finalfail2banfilterconf="/etc/fail2ban/filter.d/$app.conf"
   ynh_backup_if_checksum_is_different "$finalfail2banjailconf" 1
   ynh_backup_if_checksum_is_different "$finalfail2banfilterconf" 1
-  
+
   sudo tee $finalfail2banjailconf <<EOF
 [$app]
 enabled = true
@@ -41,7 +48,7 @@ EOF
 
   ynh_store_file_checksum "$finalfail2banjailconf"
   ynh_store_file_checksum "$finalfail2banfilterconf"
-  
+
   systemctl reload fail2ban
   local fail2ban_error="$(journalctl -u fail2ban | tail -n50 | grep "WARNING.*$app.*")"
   if [ -n "$fail2ban_error" ]

--- a/ynh_add_swap/ynh_add_swap
+++ b/ynh_add_swap/ynh_add_swap
@@ -1,8 +1,16 @@
 #!/bin/bash
 
+# Need also the helper https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_handle_getopts_args/ynh_handle_getopts_args
+
 # Argument $1 is the size of the swap in MiB
 ynh_add_swap () {
-	local swap_max_size=$(( $1 * 1024 ))
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [s]=size= )
+	local size
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+
+	local swap_max_size=$(( $size * 1024 ))
 
 	local free_space=$(df --output=avail / | sed 1d)
 	# Because we don't want to fill the disk with a swap file, divide by 2 the available space.

--- a/ynh_check_starting/ynh_check_starting
+++ b/ynh_check_starting/ynh_check_starting
@@ -1,20 +1,29 @@
 #!/bin/bash
 
+# Need also the helper https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_handle_getopts_args/ynh_handle_getopts_args
+
 # Start or restart a service and follow its booting
 #
 # usage: ynh_check_starting "Line to match" [Log file] [Timeout] [Service name]
 #
-# | arg: Line to match - The line to find in the log to attest the service have finished to boot.
-# | arg: Log file - The log file to watch; specify "systemd" to read systemd journal for specified service
+# | arg: -m, --line_to_match= - Line to match - The line to find in the log to attest the service have finished to boot.
+# | arg: -l, --app_log= - Log file - The log file to watch; specify "systemd" to read systemd journal for specified service
 #    /var/log/$app/$app.log will be used if no other log is defined.
-# | arg: Timeout - The maximum time to wait before ending the watching. Defaut 300 seconds.
-# | arg: Service name
+# | arg: -t, --timeout= - Timeout - The maximum time to wait before ending the watching. Defaut 300 seconds.
+# | arg: -n, --service_name= - Service name
 
 ynh_check_starting () {
-	local line_to_match="$1"
-	local app_log="${2:-/var/log/$service_name/$service_name.log}"
-	local timeout=${3:-300}
-	local service_name="${4:-$app}"
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [m]=line_to_match= [l]=app_log= [t]=timeout= [n]=service_name= )
+	local line_to_match
+	local app_log
+	local timeout
+	local service_name
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+	local app_log="${app_log:-/var/log/$service_name/$service_name.log}"
+	local timeout=${timeout:-300}
+	local service_name="${service_name:-$app}"
 
 	echo "Starting of $service_name" >&2
 	systemctl stop $service_name
@@ -51,11 +60,11 @@ ynh_check_starting () {
 	echo ""
 	ynh_clean_check_starting
 }
+
 # Clean temporary process and file used by ynh_check_starting
 # (usually used in ynh_clean_setup scripts)
 #
 # usage: ynh_clean_check_starting
-
 ynh_clean_check_starting () {
 	# Stop the execution of tail.
 	kill -s 15 $pid_tail 2>&1

--- a/ynh_delete_file_checksum/ynh_delete_file_checksum
+++ b/ynh_delete_file_checksum/ynh_delete_file_checksum
@@ -1,12 +1,20 @@
 #!/bin/bash
 
+# Need also the helper https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_handle_getopts_args/ynh_handle_getopts_args
+
 # Delete a file checksum from the app settings
 #
 # $app should be defined when calling this helper
 #
 # usage: ynh_remove_file_checksum file
-# | arg: file - The file for which the checksum will be deleted
+# | arg: -f, --file= - The file for which the checksum will be deleted
 ynh_delete_file_checksum () {
-	local checksum_setting_name=checksum_${1//[\/ ]/_}	# Replace all '/' and ' ' by '_'
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [f]=file= )
+	local file
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+
+	local checksum_setting_name=checksum_${file//[\/ ]/_}	# Replace all '/' and ' ' by '_'
 	ynh_app_setting_delete $app $checksum_setting_name
 }

--- a/ynh_handle_app_migration/ynh_handle_app_migration
+++ b/ynh_handle_app_migration/ynh_handle_app_migration
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Need also the helper https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_handle_getopts_args/ynh_handle_getopts_args
+
 # Make the main steps to migrate an app to its fork.
 #
 # This helper has to be used for an app which needs to migrate to a new name or a new fork
@@ -42,8 +44,8 @@
 # `(cd /tmp; echo "/tmp/$script_post_migration" | at now + 2 minutes)`
 #
 # usage: ynh_handle_app_migration migration_id migration_list
-# | arg: migration_id  - ID from which to migrate
-# | arg: migration_list - File specifying every file to move (one file per line)
+# | arg: -i, --migration_id= - ID from which to migrate
+# | arg: -l, --migration_list= - File specifying every file to move (one file per line)
 ynh_handle_app_migration ()  {
   #=================================================
   # LOAD SETTINGS
@@ -53,10 +55,14 @@ ynh_handle_app_migration ()  {
   local old_app_id=$YNH_APP_ID
   local old_app_number=$YNH_APP_INSTANCE_NUMBER
 
+  # Declare an array to define the options of this helper.
+  declare -Ar args_array=( [i]=migration_id= [l]=migration_list= )
   # Get the id from which to migrate
-  local migration_id="$1"
+  local migration_id
   # And the file with the paths to move
-  local migration_list="$2"
+  local migration_list
+  # Manage arguments with getopts
+  ynh_handle_getopts_args "$@"
 
   # Get the new app id in the manifest
   local new_app_id=$(grep \"id\": ../manifest.json | cut -d\" -f4)
@@ -137,7 +143,7 @@ ynh_handle_app_migration ()  {
         new_label=$(echo $new_app_id | cut -c1 | tr [:lower:] [:upper:])$(echo $new_app_id | cut -c2-)
         ynh_app_setting_set $new_app label $new_label
     fi
-    
+
     #=================================================
     # MOVE FILES TO THE NEW DESTINATION
     #=================================================

--- a/ynh_install_ruby/ynh_install_ruby
+++ b/ynh_install_ruby/ynh_install_ruby
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Need also the helper https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_handle_getopts_args/ynh_handle_getopts_args
+
 rbenv_install_dir="/opt/rbenv"
 # RBENV_ROOT is the directory of rbenv, it needs to be loaded as a environment variable.
 export RBENV_ROOT="$rbenv_install_dir"
@@ -50,12 +52,16 @@ fi
 # to rbenv shims (e.g. $RBENV_ROOT/shims/bundle)
 #
 # usage: ynh_install_ruby ruby_version user
-# | arg: ruby_version - Version of ruby to install.
+# | arg: -v, --ruby_version= - Version of ruby to install.
 #        If possible, prefer to use major version number (e.g. 8 instead of 8.10.0).
 #        The crontab will handle the update of minor versions when needed.
 ynh_install_ruby () {
+  # Declare an array to define the options of this helper.
+  declare -Ar args_array=( [v]=ruby_version= )
   # Use rbenv, https://github.com/rbenv/rbenv to manage the ruby versions
-  local ruby_version="$1"
+  local ruby_version
+  # Manage arguments with getopts
+  ynh_handle_getopts_args "$@"
 
   # Create $rbenv_install_dir
   mkdir -p "$rbenv_install_dir/plugins/ruby-build"

--- a/ynh_multimedia/ynh_multimedia_2
+++ b/ynh_multimedia/ynh_multimedia_2
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Need also the helper https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_handle_getopts_args/ynh_handle_getopts_args
+
 # Install or update the main directory yunohost.multimedia
 #
 # usage: ynh_multimedia_build_main_dir
@@ -25,11 +27,16 @@ ynh_multimedia_build_main_dir () {
 #
 # usage: ynh_multimedia_addfolder "Source directory" "Destination directory"
 #
-# | arg: Source directory - The real directory which contains your medias.
-# | arg: Destination directory - The name and the place of the symbolic link, relative to "/home/yunohost.multimedia"
+# | arg: -s, --source_dir= - Source directory - The real directory which contains your medias.
+# | arg: -d, --dest_dir= - Destination directory - The name and the place of the symbolic link, relative to "/home/yunohost.multimedia"
 ynh_multimedia_addfolder () {
-	local source_dir="$1"
-	local dest_dir="$2"
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [s]=source_dir= [d]=dest_dir= )
+	local source_dir
+	local dest_dir
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+
 	./yunohost.multimedia-master/script/ynh_media_addfolder.sh --source="$source_dir" --dest="$dest_dir"
 }
 
@@ -37,13 +44,18 @@ ynh_multimedia_addfolder () {
 #
 # usage: ynh_multimedia_movefolder "Source directory" "Destination directory"
 #
-# | arg: Source directory - The real directory which contains your medias.
+# | arg: -s, --source_dir= - Source directory - The real directory which contains your medias.
 # It will be moved to "Destination directory"
 # A symbolic link will replace it.
-# | arg: Destination directory - The new name and place of the directory, relative to "/home/yunohost.multimedia"
+# | arg: -d, --dest_dir= - Destination directory - The new name and place of the directory, relative to "/home/yunohost.multimedia"
 ynh_multimedia_movefolder () {
-	local source_dir="$1"
-	local dest_dir="$2"
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [s]=source_dir= [d]=dest_dir= )
+	local source_dir
+	local dest_dir
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+
 	./yunohost.multimedia-master/script/ynh_media_addfolder.sh --inv --source="$source_dir" --dest="$dest_dir"
 }
 
@@ -51,9 +63,14 @@ ynh_multimedia_movefolder () {
 #
 # usage: ynh_multimedia_addaccess user_name
 #
-# | arg: user_name - The name of the user which gain this access.
+# | arg: -u, --user_name= - The name of the user which gain this access.
 ynh_multimedia_addaccess () {
-	local user_name=$1
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [u]=user_name=)
+	local user_name
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+
 	groupadd -f multimedia
 	usermod -a -G multimedia $user_name
 }

--- a/ynh_read_manifest/ynh_read_manifest_2
+++ b/ynh_read_manifest/ynh_read_manifest_2
@@ -30,7 +30,7 @@ ynh_app_upstream_version () {
     if [ ! -e "$manifest_path" ]; then
         manifest_path="../settings/manifest.json"	# Into the restore script, the manifest is not at the same place
     fi
-    version_key=$(ynh_read_manifest --manifest "$manifest_path" --key "version")
+    version_key=$(ynh_read_manifest --manifest="$manifest_path" --key="version")
     echo "${version_key/~ynh*/}"
 }
 
@@ -46,6 +46,6 @@ ynh_app_package_version () {
     if [ ! -e "$manifest_path" ]; then
         manifest_path="../settings/manifest.json"	# Into the restore script, the manifest is not at the same place
     fi
-    version_key=$(ynh_read_manifest --manifest "$manifest_path" --key "version")
+    version_key=$(ynh_read_manifest --manifest="$manifest_path" --key="version")
     echo "${version_key/*~ynh/}"
 }

--- a/ynh_read_manifest/ynh_read_manifest_2
+++ b/ynh_read_manifest/ynh_read_manifest_2
@@ -1,13 +1,20 @@
 #!/bin/bash
 
+# Need also the helper https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_handle_getopts_args/ynh_handle_getopts_args
+
 # Read the value of a key in a ynh manifest file
 #
 # usage: ynh_read_manifest manifest key
-# | arg: manifest - Path of the manifest to read
-# | arg: key - Name of the key to find
+# | arg: -m, --manifest= - Path of the manifest to read
+# | arg: -k, --key= - Name of the key to find
 ynh_read_manifest () {
-	manifest="$1"
-	key="$2"
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [m]=manifest= [k]=key= )
+	local manifest
+	local key
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+
 	python3 -c "import sys, json;print(json.load(open('$manifest', encoding='utf-8'))['$key'])"
 }
 
@@ -23,7 +30,7 @@ ynh_app_upstream_version () {
     if [ ! -e "$manifest_path" ]; then
         manifest_path="../settings/manifest.json"	# Into the restore script, the manifest is not at the same place
     fi
-    version_key=$(ynh_read_manifest "$manifest_path" "version")
+    version_key=$(ynh_read_manifest --manifest "$manifest_path" --key "version")
     echo "${version_key/~ynh*/}"
 }
 
@@ -39,6 +46,6 @@ ynh_app_package_version () {
     if [ ! -e "$manifest_path" ]; then
         manifest_path="../settings/manifest.json"	# Into the restore script, the manifest is not at the same place
     fi
-    version_key=$(ynh_read_manifest "$manifest_path" "version")
+    version_key=$(ynh_read_manifest --manifest "$manifest_path" --key "version")
     echo "${version_key/*~ynh/}"
 }

--- a/ynh_system_reload/ynh_system_reload
+++ b/ynh_system_reload/ynh_system_reload
@@ -1,13 +1,20 @@
 #!/bin/bash
 
+# Need also the helper https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_handle_getopts_args/ynh_handle_getopts_args
+
 # Reload (or other actions) a service and print a log in case of failure.
 #
 # usage: ynh_system_reload service_name [action]
-# | arg: service_name - Name of the service to reload
-# | arg: action - Action to perform with systemctl. Default: reload
+# | arg: -n, --service_name= - Name of the service to reload
+# | arg: -a, --action= - Action to perform with systemctl. Default: reload
 ynh_system_reload () {
-        local service_name=$1
-        local action=${2:-reload}
+        # Declare an array to define the options of this helper.
+        declare -Ar args_array=( [n]=service_name= [a]=action= )
+        local service_name
+        local action
+        # Manage arguments with getopts
+        ynh_handle_getopts_args "$@"
+        local action=${action:-reload}
 
         # Reload, restart or start and print the log if the service fail to start or reload
         systemctl $action $service_name || ( journalctl --lines=20 -u $service_name >&2 && false)


### PR DESCRIPTION
Use ynh_handle_getopts_args with all our experimental helpers.
If one of your helpers is modified by this PR, please have a look and express yourself if you have anything to say about it. Even if it's to say that you don't want to use getopts for your helper.