### PR TITLE
removed not needed asc gpg check

### DIFF
--- a/ynh_add_secure_repos/ynh_add_secure_repos__2
+++ b/ynh_add_secure_repos/ynh_add_secure_repos__2
@@ -137,13 +137,7 @@ ynh_install_extra_repo () {
 	if [ -n "$key" ]
 	then
 		mkdir -p "/etc/apt/trusted.gpg.d"
-		if [[ "$(basename "$key")" =~ ".asc" ]]
-		then
-			local key_ext=asc
-		else
-			local key_ext=gpg
-		fi
-		wget -q "$key" -O - | gpg --dearmor | $wget_append /etc/apt/trusted.gpg.d/$name.$key_ext > /dev/null
+		wget -q "$key" -O - | gpg --dearmor | $wget_append /etc/apt/trusted.gpg.d/$name.gpg > /dev/null
 	fi
 
 	# Update the list of package with the new repo

--- a/ynh_add_secure_repos/ynh_add_secure_repos__3
+++ b/ynh_add_secure_repos/ynh_add_secure_repos__3
@@ -145,13 +145,7 @@ ynh_install_extra_repo () {
 	if [ -n "$key" ]
 	then
 		mkdir -p "/etc/apt/trusted.gpg.d"
-		if [[ "$(basename "$key")" =~ ".asc" ]]
-		then
-			local key_ext=asc
-		else
-			local key_ext=gpg
-		fi
-		wget -q "$key" -O - | gpg --dearmor | $wget_append /etc/apt/trusted.gpg.d/$name.$key_ext > /dev/null
+		wget -q "$key" -O - | gpg --dearmor | $wget_append /etc/apt/trusted.gpg.d/$name.gpg > /dev/null
 	fi
 
 	# Update the list of package with the new repo


### PR DESCRIPTION
as we dearmor the key file, we don't want to keep the extension.

1. if it's an asc, it will be dearmor and need be saved as key.gpg
2. if it's a gpg armored, it will be dearmor and need to be saved as key.gpg
3. if its a gpg not armored ` | gpg --dearmor |` will do nothing and need to be saved as key.gpg