### PR TITLE
Create ynh_composer__2

### DIFF
--- a/ynh_composer/ynh_composer__2
+++ b/ynh_composer/ynh_composer__2
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Execute a command with Composer
+#
+# usage: ynh_composer_exec --phpversion=phpversion [--workdir=$final_path] --commands="commands"
+# | arg: -w, --workdir - The directory from where the command will be executed. Default $final_path.
+# | arg: -c, --commands - Commands to execute.
+ynh_composer_exec () {
+	# Declare an array to define the options of this helper.
+	local legacy_args=vwc
+	declare -Ar args_array=( [v]=phpversion= [w]=workdir= [c]=commands= )
+	local phpversion
+	local workdir
+	local commands
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+	workdir="${workdir:-$final_path}"
+
+	COMPOSER_HOME="$workdir/.composer" \
+		php${phpversion} "$workdir/composer.phar" $commands \
+		-d "$workdir" --quiet --no-interaction
+}
+
+# Install and initialize Composer in the given directory
+#
+# usage: ynh_install_composer --phpversion=phpversion [--workdir=$final_path]
+# | arg: -w, --workdir - The directory from where the command will be executed. Default $final_path.
+ynh_install_composer () {
+	# Declare an array to define the options of this helper.
+	local legacy_args=vw
+	declare -Ar args_array=( [v]=phpversion= [w]=workdir= )
+	local phpversion
+	local workdir
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+	workdir="${workdir:-$final_path}"
+
+	curl -sS https://getcomposer.org/installer \
+		| COMPOSER_HOME="$workdir/.composer" \
+		php${phpversion} -- --quiet --install-dir="$workdir" \
+		|| ynh_die "Unable to install Composer."
+
+	# update dependencies to create composer.lock
+	ynh_composer_exec --phpversion="${phpversion}" --workdir="$workdir" --commands="install --no-dev" \
+		|| ynh_die "Unable to update core dependencies with Composer."
+}

--- a/ynh_composer/ynh_composer__2
+++ b/ynh_composer/ynh_composer__2
@@ -9,7 +9,7 @@ ynh_composer_exec () {
 	# Declare an array to define the options of this helper.
 	local legacy_args=vwc
 	declare -Ar args_array=( [v]=phpversion= [w]=workdir= [c]=commands= )
-	local phpversion
+	local phpversion="${phpversion:-7.0}"
 	local workdir
 	local commands
 	# Manage arguments with getopts
@@ -29,7 +29,7 @@ ynh_install_composer () {
 	# Declare an array to define the options of this helper.
 	local legacy_args=vw
 	declare -Ar args_array=( [v]=phpversion= [w]=workdir= )
-	local phpversion
+	local phpversion="${phpversion:-7.0}"
 	local workdir
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"

--- a/ynh_composer/ynh_composer__2
+++ b/ynh_composer/ynh_composer__2
@@ -9,12 +9,13 @@ ynh_composer_exec () {
 	# Declare an array to define the options of this helper.
 	local legacy_args=vwc
 	declare -Ar args_array=( [v]=phpversion= [w]=workdir= [c]=commands= )
-	local phpversion="${phpversion:-7.0}"
+	local phpversion
 	local workdir
 	local commands
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 	workdir="${workdir:-$final_path}"
+	phpversion="${phpversion:-7.0}"
 
 	COMPOSER_HOME="$workdir/.composer" \
 		php${phpversion} "$workdir/composer.phar" $commands \
@@ -29,11 +30,12 @@ ynh_install_composer () {
 	# Declare an array to define the options of this helper.
 	local legacy_args=vw
 	declare -Ar args_array=( [v]=phpversion= [w]=workdir= )
-	local phpversion="${phpversion:-7.0}"
+	local phpversion
 	local workdir
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 	workdir="${workdir:-$final_path}"
+	phpversion="${phpversion:-7.0}"
 
 	curl -sS https://getcomposer.org/installer \
 		| COMPOSER_HOME="$workdir/.composer" \


### PR DESCRIPTION
to let provide phpversion to ynh_composer.

Since https://github.com/YunoHost-Apps/Experimental_helpers/commit/abcc23156519f5dbce15129bcd9a5f3490421f6d :

When installing php using ynh_install_php, at the end of the installation php-cli is switched back to 7.0.
If phpversion is not define for composer, composer use php7.0 instead of the version required.