### PR TITLE
Create ynh_sanitize_name

### DIFF
--- a/ynh_sanitize_name/ynh_sanitize_name
+++ b/ynh_sanitize_name/ynh_sanitize_name
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Sanitize a string intended to be the firstname lastname
 # (More specifically : removing - . and _)
 #

--- a/ynh_sanitize_name/ynh_sanitize_name
+++ b/ynh_sanitize_name/ynh_sanitize_name
@@ -1,0 +1,20 @@
+# Sanitize a string intended to be the firstname lastname
+# (More specifically : removing - . and _)
+#
+# example: username=$(ynh_sanitize_name --name=$app)
+#
+# usage: ynh_sanitize_name --name=name
+# | arg: -n, --name - name to correct/sanitize
+# | ret: the corrected name
+#
+ynh_sanitize_name () {
+	# Declare an array to define the options of this helper.
+	local legacy_args=n
+	declare -Ar args_array=( [n]=name= )
+	local name
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+
+	# We should avoid having - and . in the name of databases. They are replaced by _
+	echo ${name//[-._]/}
+}


### PR DESCRIPTION
As now with YunoHost 3.6 we are able to create users with `yunohost user create` without providing the admin password

And as some applications need to have a dedicated ldap users to configure ldap connexions for authentication

The best way to create that dedicated user would be to use the `$app`. For example dedicated username could be `${app}ldap` or `ldap$app`

But if you install twice the same application, in the second installation `$app` value would be something like `example__2` for the example application

But `yunohost user create` has some limitations regarding username, firstname and lastname : https://github.com/YunoHost/yunohost/blob/ac7102a0caee9c6d2d8808ef4b345edfbdbb54e8/data/actionsmap/yunohost.yml#L75-L108

So the best is to sanitize the name to have something like:
```
ldap_user=$(ynh_sanitize_name --name="${app}ldap")
ldap_password=$(ynh_string_random --length=8)

yunohost user create $ldap_user --firstname $ldap_user --lastname $ldap_user --mail ${ldap_user}@$domain --password $ldap_password -q 0
```
