### PR TITLE
Update ynh_add_swap

### DIFF
--- a/ynh_add_swap/ynh_add_swap
+++ b/ynh_add_swap/ynh_add_swap
@@ -48,6 +48,12 @@ ynh_add_swap () {
 	# If there's enough space for a swap, and no existing swap here
 	if [ $swap_size -ne 0 ] && [ ! -e /swap_$app ]
 	then
+		# Create file
+		truncate -s 0 /swap_$app
+		
+		# set the No_COW attribute on the swapfile with chattr
+		chattr +C /swap_$app
+		
 		# Preallocate space for the swap file, fallocate may sometime not be used, use dd instead in this case
 		if ! fallocate -l ${swap_size}K /swap_$app
 		then


### PR DESCRIPTION
On my ynh-dev, the function `ynh_add_swap` faild with the error:
> swapon: /swap_$app: swapon failed: Invalid argument

Fixed with the attribute `No_COW`: https://wiki.archlinux.org/index.php/Swap#Swap_file

I don't know what it really means, but it doesn't fail anymore \o/