### PR TITLE
Adding additional arguments to composer install

### DIFF
--- a/ynh_composer/ynh_composer__2
+++ b/ynh_composer/ynh_composer__2
@@ -2,7 +2,8 @@
 
 # Execute a command with Composer
 #
-# usage: ynh_composer_exec --phpversion=phpversion [--workdir=$final_path] --commands="commands"
+# usage: ynh_composer_exec [--phpversion=phpversion] [--workdir=$final_path] --commands="commands"
+# | arg: -v, --phpversion - PHP version to use with composer
 # | arg: -w, --workdir - The directory from where the command will be executed. Default $final_path.
 # | arg: -c, --commands - Commands to execute.
 ynh_composer_exec () {
@@ -24,12 +25,13 @@ ynh_composer_exec () {
 
 # Install and initialize Composer in the given directory
 #
-# usage: ynh_install_composer --phpversion=phpversion [--workdir=$final_path] [--install_args="--optimize-autoloader"]
+# usage: ynh_install_composer [--phpversion=phpversion] [--workdir=$final_path] [--install_args="--optimize-autoloader"]
+# | arg: -v, --phpversion - PHP version to use with composer
 # | arg: -w, --workdir - The directory from where the command will be executed. Default $final_path.
 # | arg: -a, --install_args - Additional arguments provided to the composer install. Argument --no-dev already include
 ynh_install_composer () {
 	# Declare an array to define the options of this helper.
-	local legacy_args=vw
+	local legacy_args=vwa
 	declare -Ar args_array=( [v]=phpversion= [w]=workdir= [a]=install_args=)
 	local phpversion
 	local workdir
@@ -38,6 +40,7 @@ ynh_install_composer () {
 	ynh_handle_getopts_args "$@"
 	workdir="${workdir:-$final_path}"
 	phpversion="${phpversion:-7.0}"
+	install_args="${install_args:-}"
 
 	curl -sS https://getcomposer.org/installer \
 		| COMPOSER_HOME="$workdir/.composer" \

--- a/ynh_composer/ynh_composer__2
+++ b/ynh_composer/ynh_composer__2
@@ -24,14 +24,16 @@ ynh_composer_exec () {
 
 # Install and initialize Composer in the given directory
 #
-# usage: ynh_install_composer --phpversion=phpversion [--workdir=$final_path]
+# usage: ynh_install_composer --phpversion=phpversion [--workdir=$final_path] [--install_args="--optimize-autoloader"]
 # | arg: -w, --workdir - The directory from where the command will be executed. Default $final_path.
+# | arg: -a, --install_args - Additional arguments provided to the composer install. Argument --no-dev already include
 ynh_install_composer () {
 	# Declare an array to define the options of this helper.
 	local legacy_args=vw
-	declare -Ar args_array=( [v]=phpversion= [w]=workdir= )
+	declare -Ar args_array=( [v]=phpversion= [w]=workdir= [a]=install_args=)
 	local phpversion
 	local workdir
+	local install_args
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 	workdir="${workdir:-$final_path}"
@@ -43,6 +45,6 @@ ynh_install_composer () {
 		|| ynh_die "Unable to install Composer."
 
 	# update dependencies to create composer.lock
-	ynh_composer_exec --phpversion="${phpversion}" --workdir="$workdir" --commands="install --no-dev" \
+	ynh_composer_exec --phpversion="${phpversion}" --workdir="$workdir" --commands="install --no-dev $install_args" \
 		|| ynh_die "Unable to update core dependencies with Composer."
 }


### PR DESCRIPTION
Sometimes, we need additional arguments during `composer install` like `--optimize-autoloader` or other stuff.

with that we are able to provide them if requested