### PR TITLE
Force cleanup even on error when installing ruby

### DIFF
--- a/ynh_install_ruby/ynh_install_ruby__2
+++ b/ynh_install_ruby/ynh_install_ruby__2
@@ -107,6 +107,7 @@ ynh_install_ruby () {
     local legacy_args=v
     local -A args_array=( [v]=ruby_version= )
     local ruby_version
+    local rbenv
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
@@ -117,98 +118,108 @@ ynh_install_ruby () {
     PATH=$(echo $CLEAR_PATH | sed 's@/usr/local/bin:@@')
 
     # Move an existing Ruby binary, to avoid to block rbenv
+    ynh_print_info "Temporarily move the ruby binary"
     test -x /usr/bin/ruby && mv /usr/bin/ruby /usr/bin/ruby_rbenv
+    (
+        set -eE
 
-    # Install or update rbenv
-    rbenv="$(command -v rbenv $rbenv_install_dir/bin/rbenv | grep "$rbenv_install_dir/bin/rbenv" | head -1)"
-    if [ -n "$rbenv" ]; then
-        ynh_print_info --message="rbenv already seems installed in \`$rbenv'."
-        pushd "${rbenv%/*/*}"
-            if git remote -v 2>/dev/null | grep "https://github.com/rbenv/rbenv.git"; then
-                ynh_print_info --message="Trying to update with git..."
-                git pull -q --tags origin master
-                ynh_ruby_try_bash_extension
-            else
-                ynh_print_info --message="Reinstalling rbenv with git..."
-                cd ..
-                ynh_secure_remove --file=$rbenv_install_dir
-                mkdir -p $rbenv_install_dir
-                cd $rbenv_install_dir
+        cleanup() {
+            ynh_print_info "Restore the previously moved ruby binary"
+            if [ -x /usr/bin/ruby_rbenv ]; then
+                mv /usr/bin/ruby_rbenv /usr/bin/ruby
+            fi
+        }
+
+        trap cleanup EXIT
+
+        # Install or update rbenv
+        rbenv="$(command -v rbenv $rbenv_install_dir/bin/rbenv | grep "$rbenv_install_dir/bin/rbenv" | head -1)"
+        if [ -n "$rbenv" ]; then
+            ynh_print_info --message="rbenv already seems installed in \`$rbenv'."
+            pushd "${rbenv%/*/*}"
+                if git remote -v 2>/dev/null | grep "https://github.com/rbenv/rbenv.git"; then
+                    ynh_print_info --message="Trying to update with git..."
+                    git pull -q --tags origin master
+                    ynh_ruby_try_bash_extension
+                else
+                    ynh_print_info --message="Reinstalling rbenv with git..."
+                    cd ..
+                    ynh_secure_remove --file=$rbenv_install_dir
+                    mkdir -p $rbenv_install_dir
+                    cd $rbenv_install_dir
+                    git init -q
+                    git remote add -f -t master origin https://github.com/rbenv/rbenv.git > /dev/null 2>&1
+                    git checkout -q -b master origin/master
+                    ynh_ruby_try_bash_extension
+                    rbenv=$rbenv_install_dir/bin/rbenv
+                fi
+            popd
+        else
+            ynh_print_info --message="Installing rbenv with git..."
+            mkdir -p $rbenv_install_dir
+            pushd $rbenv_install_dir
                 git init -q
                 git remote add -f -t master origin https://github.com/rbenv/rbenv.git > /dev/null 2>&1
                 git checkout -q -b master origin/master
                 ynh_ruby_try_bash_extension
                 rbenv=$rbenv_install_dir/bin/rbenv
-            fi
-        popd
-    else
-        ynh_print_info --message="Installing rbenv with git..."
-        mkdir -p $rbenv_install_dir
-        pushd $rbenv_install_dir
-            git init -q
-            git remote add -f -t master origin https://github.com/rbenv/rbenv.git > /dev/null 2>&1
-            git checkout -q -b master origin/master
-            ynh_ruby_try_bash_extension
-            rbenv=$rbenv_install_dir/bin/rbenv
-        popd
-    fi
+            popd
+        fi
 
-    ruby_build="$(command -v "$rbenv_install_dir"/plugins/*/bin/rbenv-install rbenv-install | head -1)"
-    if [ -n "$ruby_build" ]; then
-        ynh_print_info --message="\`rbenv install' command already available in \`$ruby_build'."
-        pushd "${ruby_build%/*/*}"
-            if git remote -v 2>/dev/null | grep "https://github.com/rbenv/ruby-build.git"; then
-                ynh_print_info --message="Trying to update rbenv with git..."
-                git pull -q origin master
-            fi
-        popd
-    else
-        ynh_print_info --message="Installing ruby-build with git..."
-        mkdir -p "${rbenv_install_dir}/plugins"
-        git clone -q https://github.com/rbenv/ruby-build.git "${rbenv_install_dir}/plugins/ruby-build"
-    fi
+        ruby_build="$(command -v "$rbenv_install_dir"/plugins/*/bin/rbenv-install rbenv-install | head -1)"
+        if [ -n "$ruby_build" ]; then
+            ynh_print_info --message="\`rbenv install' command already available in \`$ruby_build'."
+            pushd "${ruby_build%/*/*}"
+                if git remote -v 2>/dev/null | grep "https://github.com/rbenv/ruby-build.git"; then
+                    ynh_print_info --message="Trying to update rbenv with git..."
+                    git pull -q origin master
+                fi
+            popd
+        else
+            ynh_print_info --message="Installing ruby-build with git..."
+            mkdir -p "${rbenv_install_dir}/plugins"
+            git clone -q https://github.com/rbenv/ruby-build.git "${rbenv_install_dir}/plugins/ruby-build"
+        fi
 
-    rbenv_alias="$(command -v "$rbenv_install_dir"/plugins/*/bin/rbenv-alias rbenv-alias | head -1)"
-    if [ -n "$rbenv_alias" ]; then
-        ynh_print_info --message="\`rbenv alias' command already available in \`$rbenv_alias'."
-        pushd "${rbenv_alias%/*/*}"
-            if git remote -v 2>/dev/null | grep "https://github.com/tpope/rbenv-aliases.git"; then
-                ynh_print_info --message="Trying to update rbenv-aliases with git..."
-                git pull -q origin master
-            fi
-        popd
-    else
-        ynh_print_info --message="Installing rbenv-aliases with git..."
-        mkdir -p "${rbenv_install_dir}/plugins"
-        git clone -q https://github.com/tpope/rbenv-aliases.git "${rbenv_install_dir}/plugins/rbenv-aliase"
-    fi
+        rbenv_alias="$(command -v "$rbenv_install_dir"/plugins/*/bin/rbenv-alias rbenv-alias | head -1)"
+        if [ -n "$rbenv_alias" ]; then
+            ynh_print_info --message="\`rbenv alias' command already available in \`$rbenv_alias'."
+            pushd "${rbenv_alias%/*/*}"
+                if git remote -v 2>/dev/null | grep "https://github.com/tpope/rbenv-aliases.git"; then
+                    ynh_print_info --message="Trying to update rbenv-aliases with git..."
+                    git pull -q origin master
+                fi
+            popd
+        else
+            ynh_print_info --message="Installing rbenv-aliases with git..."
+            mkdir -p "${rbenv_install_dir}/plugins"
+            git clone -q https://github.com/tpope/rbenv-aliases.git "${rbenv_install_dir}/plugins/rbenv-aliase"
+        fi
 
-    rbenv_latest="$(command -v "$rbenv_install_dir"/plugins/*/bin/rbenv-latest rbenv-latest | head -1)"
-    if [ -n "$rbenv_latest" ]; then
-        ynh_print_info --message="\`rbenv latest' command already available in \`$rbenv_latest'."
-        pushd "${rbenv_latest%/*/*}"
-            if git remote -v 2>/dev/null | grep "https://github.com/momo-lab/xxenv-latest.git"; then
-                ynh_print_info --message="Trying to update xxenv-latest with git..."
-                git pull -q origin master
-            fi
-        popd
-    else
-        ynh_print_info --message="Installing xxenv-latest with git..."
-        mkdir -p "${rbenv_install_dir}/plugins"
-        git clone -q https://github.com/momo-lab/xxenv-latest.git "${rbenv_install_dir}/plugins/xxenv-latest"
-    fi
+        rbenv_latest="$(command -v "$rbenv_install_dir"/plugins/*/bin/rbenv-latest rbenv-latest | head -1)"
+        if [ -n "$rbenv_latest" ]; then
+            ynh_print_info --message="\`rbenv latest' command already available in \`$rbenv_latest'."
+            pushd "${rbenv_latest%/*/*}"
+                if git remote -v 2>/dev/null | grep "https://github.com/momo-lab/xxenv-latest.git"; then
+                    ynh_print_info --message="Trying to update xxenv-latest with git..."
+                    git pull -q origin master
+                fi
+            popd
+        else
+            ynh_print_info --message="Installing xxenv-latest with git..."
+            mkdir -p "${rbenv_install_dir}/plugins"
+            git clone -q https://github.com/momo-lab/xxenv-latest.git "${rbenv_install_dir}/plugins/xxenv-latest"
+        fi
 
-    # Enable caching
-    mkdir -p "${rbenv_install_dir}/cache"
+        # Enable caching
+        mkdir -p "${rbenv_install_dir}/cache"
 
-    # Create shims directory if needed
-    mkdir -p "${rbenv_install_dir}/shims"
+        # Create shims directory if needed
+        mkdir -p "${rbenv_install_dir}/shims"
 
-    # Restore /usr/local/bin in PATH
-    PATH=$CLEAR_PATH
-
-    # And replace the old Ruby binary
-    test -x /usr/bin/ruby_rbenv && mv /usr/bin/ruby_rbenv /usr/bin/ruby
+        # Restore /usr/local/bin in PATH
+        PATH=$CLEAR_PATH
+    )
 
     # Install the requested version of Ruby
     local final_ruby_version=$(rbenv latest --print $ruby_version)
@@ -287,7 +298,7 @@ ynh_cleanup_ruby () {
             required_ruby_versions="${installed_app_ruby_version}\n${required_ruby_versions}"
         fi
     done
-    
+
     # Remove no more needed Ruby versions
     local installed_ruby_versions=$(rbenv versions --bare --skip-aliases | grep -Ev '/')
     for installed_ruby_version in $installed_ruby_versions


### PR DESCRIPTION
## Problem

There are theoretically some cases where the installer is interrupted because of failures or because the user triggers the interruption.

In such case, there is no guarantee that the ruby binary is restored.

## Solution

Use a sub-shell with a trap of exit (the `cleanup` function. Whether the sub-shell fails or suceeds, the trap is run.